### PR TITLE
HTMX integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.Manifest.toml
 docs/build
 *ipynb*
+.vscode

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ node
 # <div id="my_id"></div>
 ```
 
-There are scenarios where you might need to use hypenated attributes. In such cases, you can add the attributes using `Pair{Symbol,String}` as keyword arguments:
+There are scenarios where you might need to use hyphenated attributes. In such cases, you can add the attributes using `Pair{Symbol,String}` as keyword arguments:
 
 ```julia
 node = Cobweb.h.div
@@ -145,7 +145,7 @@ node.hx.target = "#my_target"
 # <div hx-target="#my_target"></div>
 ```
 
-There are a few HTMX-specific attributes that are hypenated. To ensure a homogeneous syntax, these attributes can still be added using the normal syntax (e.g. `pushurl` will be mapped to `hx-push-url`):
+There are a few HTMX-specific attributes that are hyphenated. To ensure a homogeneous syntax, these attributes can still be added using the normal syntax (e.g. `pushurl` will be mapped to `hx-push-url`):
 
 ```julia
 node = Cobweb.h.div
@@ -159,8 +159,17 @@ Alternatively, the following syntax can be used:
 ```julia
 node = Cobweb.h.div
 
-node.hx("push-url" => "true")
+node.hx(; Symbol("push-url")=>"true")
 # <div hx-push-url="true"></div>
+```
+
+If you want to add both regular attributes and HTMX-specific attributes, you can mix the two approaches above:
+
+```julia
+node = Cobweb.h.div
+
+node(; id="my_id", class="wide").hx(; target="#my_target")
+# <div id="my_id" class="wide" hx-target="#my_target"></div>
 ```
 
 The take-away is that the `hx` prefix doesn't need to be explicitly added to the attribute name when using the `hx` syntax.

--- a/README.md
+++ b/README.md
@@ -171,8 +171,15 @@ node = Cobweb.h.div
 node(; id="my_id", class="wide").hx(; target="#my_target")
 # <div id="my_id" class="wide" hx-target="#my_target"></div>
 ```
-
 The take-away is that the `hx` prefix doesn't need to be explicitly added to the attribute name when using the `hx` syntax.
+
+**Important**: HTMX requires loading the HTMX library. Altough the CDN is not reccomended for production, it is the easiest way to get started:
+
+```julia
+Cobweb.hx.cdn
+# <script src="https://unpkg.com/htmx.org@1.9.2" integrity="sha384-L6OqL9pRWyyFU3+/bjdSri+iIphTN/bvYyM37tICVyOJkWZLpP2vGn6VUEXgzg6h" crossorigin="anonymous"></script>
+```
+
 
 ### Children
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ julia> node = Cobweb.h.div
     - Keyword arguments add *attributes*:
     ```julia
     julia> node = node(; id = "myid", class="myclass")
-    # <div id="myid"></div>
+    # <div id="myid" class="myclass"></div>
     ```
 
 - There's convenient syntax for appending classes as well:
@@ -125,6 +125,45 @@ node
 # <div id="my_id"></div>
 ```
 
+There are scenarios where you might need to use hypenated attributes. In such cases, you can add the attributes using `Pair{Symbol,String}` as keyword arguments:
+
+```julia
+node = Cobweb.h.div
+
+node(; Symbol("data-toggle") => "modal")
+# <div data-toggle="modal"></div>
+```
+
+#### HTMX integration
+
+- The HTMX specific attributes can be added similar to the HTML attributes using the following syntax:
+
+```julia
+node = Cobweb.h.div
+
+node.hx.target = "#my_target"
+# <div hx-target="#my_target"></div>
+```
+
+There are a few HTMX-specific attributes that are hypenated. To ensure a homogeneous syntax, these attributes can still be added using the normal syntax (e.g. `pushurl` will be mapped to `hx-push-url`):
+
+```julia
+node = Cobweb.h.div
+
+node.hx.pushurl = "true"
+# <div hx-push-url="true"></div>
+```
+
+Alternatively, the following syntax can be used:
+
+```julia
+node = Cobweb.h.div
+
+node.hx("push-url" => "true")
+# <div hx-push-url="true"></div>
+```
+
+The take-away is that the `hx` prefix doesn't need to be explicitly added to the attribute name when using the `hx` syntax.
 
 ### Children
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ node(; Symbol("data-toggle") => "modal")
 
 #### HTMX integration
 
-- The HTMX specific attributes can be added similar to the HTML attributes using the following syntax:
+- The [HTMX](https://htmx.org/docs/) specific attributes can be added similar to the HTML attributes using the following syntax:
 
 ```julia
 node = Cobweb.h.div

--- a/src/Cobweb.jl
+++ b/src/Cobweb.jl
@@ -55,7 +55,13 @@ Base.getproperty(o::Node, class::String) = o(class = lstrip(get(o, :class, "") *
 
 # methods that pass through to attrs(o)
 Base.propertynames(o::Node) = Symbol.(keys(o))
-Base.getproperty(o::Node, name::Symbol) = attrs(o)[string(name)]
+function Base.getproperty(o::Node, name::Symbol)
+    if name == :hx
+        hx(o)
+    else
+        attrs(o)[string(name)]
+    end
+end
 Base.setproperty!(o::Node, name::Symbol, x) = attrs(o)[string(name)] = string(x)
 Base.get(o::Node, name, val) = get(attrs(o), string(name), string(val))
 Base.get!(o::Node, name, val) = get!(attrs(o), string(name), string(val))
@@ -100,7 +106,7 @@ const HTML5_TAGS = [:a,:abbr,:address,:area,:article,:aside,:audio,:b,:base,:bdi
 
 const VOID_ELEMENTS = [:area,:base,:br,:col,:command,:embed,:hr,:img,:input,:keygen,:link,:meta,:param,:source,:track,:wbr]
 
-SVG2_TAGS = [:a,:animate,:animateMotion,:animateTransform,:audio,:canvas,:circle,:clipPath,:defs,:desc,:discard,:ellipse,:feBlend,:feColorMatrix,:feComponentTransfer,:feComposite,:feConvolveMatrix,:feDiffuseLighting,:feDisplacementMap,:feDistantLight,:feDropShadow,:feFlood,:feFuncA,:feFuncB,:feFuncG,:feFuncR,:feGaussianBlur,:feImage,:feMerge,:feMergeNode,:feMorphology,:feOffset,:fePointLight,:feSpecularLighting,:feSpotLight,:feTile,:feTurbulence,:filter,:foreignObject,:g,:iframe,:image,:line,:linearGradient,:marker,:mask,:metadata,:mpath,:path,:pattern,:polygon,:polyline,:radialGradient,:rect,:script,:set,:stop,:style,:svg,:switch,:symbol,:text,:textPath,:title,:tspan,:unknown,:use,:video,:view]
+const SVG2_TAGS = [:a,:animate,:animateMotion,:animateTransform,:audio,:canvas,:circle,:clipPath,:defs,:desc,:discard,:ellipse,:feBlend,:feColorMatrix,:feComponentTransfer,:feComposite,:feConvolveMatrix,:feDiffuseLighting,:feDisplacementMap,:feDistantLight,:feDropShadow,:feFlood,:feFuncA,:feFuncB,:feFuncG,:feFuncR,:feGaussianBlur,:feImage,:feMerge,:feMergeNode,:feMorphology,:feOffset,:fePointLight,:feSpecularLighting,:feSpotLight,:feTile,:feTurbulence,:filter,:foreignObject,:g,:iframe,:image,:line,:linearGradient,:marker,:mask,:metadata,:mpath,:path,:pattern,:polygon,:polyline,:radialGradient,:rect,:script,:set,:stop,:style,:svg,:switch,:symbol,:text,:textPath,:title,:tspan,:unknown,:use,:video,:view]
 
 macro h(ex)
     esc(_h(ex))
@@ -301,6 +307,9 @@ function iframe(x; height=250, width=750, kw...)
     IFrame(x; height=height, width=width, kw...)
 end
 
+include("htmx.jl")
 include("parser.jl")
+
+
 
 end #module

--- a/src/Cobweb.jl
+++ b/src/Cobweb.jl
@@ -55,6 +55,8 @@ Base.getproperty(o::Node, class::String) = o(class = lstrip(get(o, :class, "") *
 
 # methods that pass through to attrs(o)
 Base.propertynames(o::Node) = Symbol.(keys(o))
+
+# updated to accomodate .hx syntactic sugar
 function Base.getproperty(o::Node, name::Symbol)
     if name == :hx
         hx(o)

--- a/src/htmx.jl
+++ b/src/htmx.jl
@@ -2,28 +2,33 @@ struct hx
     node::Node    
 end
 
-const HTMX_ATTRS = [:trigger, :target, :post, :get, :put, :patch, :delete, :swap, :indicator, :sync, :preserve, :include, :params, :encoding, :confirm, :disinherit, :boost, :select, Symbol("push-url"), Symbol("select-oob"), Symbol("swap-oob"), Symbol("history-elt")]
+const HTMX_ATTRS = [:trigger, :target, :post, :get, :put, :patch, :delete, :swap, :indicator, :sync, :preserve, :include, :params, :encoding, :confirm, :disinherit, :boost, :select, :pushurl, :selectoob, :swapoob, :historyelt]
+const HIPHENATED = Dict(:pushurl => Symbol("push-url"), :selectoob => Symbol("select-oob"), :swapoob => Symbol("swap-oob"), :historyelt => Symbol("history-elt"))
 
-#Base.propertynames(x::hx) = Symbol.(keys(x.node))
+getattr(x::Symbol) = haskey(HIPHENATED, x) ? HIPHENATED[x] : x
+
 Base.propertynames(::hx) = HTMX_ATTRS
 Base.propertynames(::Type{hx}) = HTMX_ATTRS
-Base.getproperty(x::hx, name::Symbol) = name == :node ? getfield(x, :node) : attrs(x.node)["hx-$name"]
-Base.getproperty(::Type{hx}, name::Symbol) = name in HTMX_ATTRS ? name : error("hx does not have property $name")
-Base.setproperty!(x::hx, name::Symbol, v) = attrs(x.node)["hx-$name"] = string(v)
+Base.getproperty(x::hx, name::Symbol) = name == :node ? getfield(x, :node) : attrs(x.node)["hx-$(getattr(name))"]
+Base.getproperty(::Type{hx}, name::Symbol) = name in HTMX_ATTRS ? getattr(name) : error("hx does not have property $name")
+Base.setproperty!(x::hx, name::Symbol, v) = attrs(x.node)["hx-$(getattr(name))"] = string(v)
 
-Base.get(x::hx, name, val) = get(attrs(x.node), string(name), string(val))
-Base.get!(x::hx, name, val) = get!(attrs(x.node), string(name), string(val))
-Base.haskey(x::hx, name) = haskey(attrs(x.node), string(name))
+Base.get(x::hx, name, val) = get(attrs(x.node), string(getattr(name)), string(val))
+Base.get!(x::hx, name, val) = get!(attrs(x.node), string(getattr(name)), string(val))
+Base.haskey(x::hx, name) = haskey(attrs(x.node), string(getattr(name)))
 Base.keys(x::hx) = keys(attrs(x.node))
 
-(x::hx)(name::Union{String,Symbol}, value::Union{String,Symbol}) = attrs(x.node)["hx-$name"] = "$value"
-(x::hx)(p::Pair{Union{String,Symbol},Union{String,Symbol}}) = attrs(x.node)["hx-$(p[1])"] = "$(p[2])"
+(x::hx)(name::Symbol, value::Union{String,Symbol}) = attrs(x.node)["hx-$(getattr(name))"] = "$value"
+(x::hx)(name::String, value::Union{String,Symbol}) = x(Symbol(name), value)
+(x::hx)(p::Pair{Symbol,<:Union{String,Symbol}}) = attrs(x.node)["hx-$(getattr(p[1]))"] = "$(p[2])"
+(x::hx)(p::Pair{String,<:Union{String,Symbol}}) = x(Symbol(p[1]), p[2])
 
+# swap related stuff
 const SWAP_ATTRS = [:innerHTML, :outerHTML, :afterbegin, :afterend, :beforebegin, :beforeend]
-swap() = (:swap => :innerHTML)
+swap() = (:swap => :innerHTML) # the default - don't expect this to be used
 swap(name::Symbol) = name in SWAP_ATTRS ? (:swap => name) : error("swap does not have property $name")
 Base.propertynames(::typeof(swap)) = SWAP_ATTRS
-Base.getproperty(::typeof(swap), name::Symbol) = swap(name)
+Base.getproperty(::typeof(swap), name::Symbol) = name in SWAP_ATTRS ? name : error("swap does not have property $name")
 
 
 

--- a/src/htmx.jl
+++ b/src/htmx.jl
@@ -4,7 +4,7 @@ end
 
 const HTMX_ATTRS = [:trigger, :target, :post, :get, :put, :patch, :delete, :swap, :indicator, :sync, :preserve, :include, :params, :encoding, :confirm, :disinherit, :boost, :select, Symbol("push-url"), Symbol("select-oob"), Symbol("swap-oob"), Symbol("history-elt")]
 
-Base.propertynames(x::hx) = Symbol.(keys(x.node))
+#Base.propertynames(x::hx) = Symbol.(keys(x.node))
 Base.propertynames(::hx) = HTMX_ATTRS
 Base.propertynames(::Type{hx}) = HTMX_ATTRS
 Base.getproperty(x::hx, name::Symbol) = name == :node ? getfield(x, :node) : attrs(x.node)["hx-$name"]
@@ -16,6 +16,15 @@ Base.get!(x::hx, name, val) = get!(attrs(x.node), string(name), string(val))
 Base.haskey(x::hx, name) = haskey(attrs(x.node), string(name))
 Base.keys(x::hx) = keys(attrs(x.node))
 
-(x::hx)(name::String, value::String) = attrs(x.node)["hx-$name"] = value
-(x::hx)(name::Symbol, value::String) = attrs(x.node)["hx-$name"] = value
+(x::hx)(name::Union{String,Symbol}, value::Union{String,Symbol}) = attrs(x.node)["hx-$name"] = "$value"
+(x::hx)(p::Pair{Union{String,Symbol},Union{String,Symbol}}) = attrs(x.node)["hx-$(p[1])"] = "$(p[2])"
+
+const SWAP_ATTRS = [:innerHTML, :outerHTML, :afterbegin, :afterend, :beforebegin, :beforeend]
+swap() = (:swap => :innerHTML)
+swap(name::Symbol) = name in SWAP_ATTRS ? (:swap => name) : error("swap does not have property $name")
+Base.propertynames(::typeof(swap)) = SWAP_ATTRS
+Base.getproperty(::typeof(swap), name::Symbol) = swap(name)
+
+
+
 

--- a/src/htmx.jl
+++ b/src/htmx.jl
@@ -2,16 +2,20 @@ struct hx
     node::Node    
 end
 
-const HTMX_ATTRS = [:trigger, :target, :post, :get, :put, :patch, :delete, :swap, :indicator, :sync, Symbol("swap-oob")]
+const HTMX_ATTRS = [:trigger, :target, :post, :get, :put, :patch, :delete, :swap, :indicator, :sync, :preserve, :include, :params, :encoding, :confirm, :disinherit, :boost, :select, Symbol("push-url"), Symbol("select-oob"), Symbol("swap-oob"), Symbol("history-elt")]
 
 Base.propertynames(x::hx) = Symbol.(keys(x.node))
 Base.propertynames(::hx) = HTMX_ATTRS
 Base.propertynames(::Type{hx}) = HTMX_ATTRS
 Base.getproperty(x::hx, name::Symbol) = name == :node ? getfield(x, :node) : attrs(x.node)["hx-$name"]
+Base.getproperty(::Type{hx}, name::Symbol) = name in HTMX_ATTRS ? name : error("hx does not have property $name")
 Base.setproperty!(x::hx, name::Symbol, v) = attrs(x.node)["hx-$name"] = string(v)
 
 Base.get(x::hx, name, val) = get(attrs(x.node), string(name), string(val))
 Base.get!(x::hx, name, val) = get!(attrs(x.node), string(name), string(val))
 Base.haskey(x::hx, name) = haskey(attrs(x.node), string(name))
 Base.keys(x::hx) = keys(attrs(x.node))
+
+(x::hx)(name::String, value::String) = attrs(x.node)["hx-$name"] = value
+(x::hx)(name::Symbol, value::String) = attrs(x.node)["hx-$name"] = value
 

--- a/src/htmx.jl
+++ b/src/htmx.jl
@@ -2,6 +2,11 @@ struct hx
     node::Node    
 end
 
+_node(o::hx) = getfield(o, :node)
+tag(o::hx) = getfield(o |> _node, :tag)
+attrs(o::hx) = getfield(o |> _node, :attrs)
+children(o::hx) = getfield(o |> _node, :children)
+
 const HTMX_ATTRS = [:trigger, :target, :post, :get, :put, :patch, :delete, :swap, :indicator, :sync, :preserve, :include, :params, :encoding, :confirm, :disinherit, :boost, :select, :pushurl, :selectoob, :swapoob, :historyelt]
 const HIPHENATED = Dict(:pushurl => Symbol("push-url"), :selectoob => Symbol("select-oob"), :swapoob => Symbol("swap-oob"), :historyelt => Symbol("history-elt"))
 
@@ -18,10 +23,11 @@ Base.get!(x::hx, name, val) = get!(attrs(x.node), string(getattr(name)), string(
 Base.haskey(x::hx, name) = haskey(attrs(x.node), string(getattr(name)))
 Base.keys(x::hx) = keys(attrs(x.node))
 
-(x::hx)(name::Symbol, value::Union{String,Symbol}) = attrs(x.node)["hx-$(getattr(name))"] = "$value"
-(x::hx)(name::String, value::Union{String,Symbol}) = x(Symbol(name), value)
-(x::hx)(p::Pair{Symbol,<:Union{String,Symbol}}) = attrs(x.node)["hx-$(getattr(p[1]))"] = "$(p[2])"
-(x::hx)(p::Pair{String,<:Union{String,Symbol}}) = x(Symbol(p[1]), p[2])
+function (x::hx)(; kw...)
+    hxattrs = OrderedDict("hx-$(getattr(Symbol(k)))" => string(v) for (k,v) in kw) 
+    Node(tag(x), merge(attrs(x), hxattrs), children(x))
+end
+
 
 # swap related stuff
 const SWAP_ATTRS = [:innerHTML, :outerHTML, :afterbegin, :afterend, :beforebegin, :beforeend]

--- a/src/htmx.jl
+++ b/src/htmx.jl
@@ -1,0 +1,17 @@
+struct hx
+    node::Node    
+end
+
+const HTMX_ATTRS = [:trigger, :target, :post, :get, :put, :patch, :delete, :swap, :indicator, :sync, Symbol("swap-oob")]
+
+Base.propertynames(x::hx) = Symbol.(keys(x.node))
+Base.propertynames(::hx) = HTMX_ATTRS
+Base.propertynames(::Type{hx}) = HTMX_ATTRS
+Base.getproperty(x::hx, name::Symbol) = name == :node ? getfield(x, :node) : attrs(x.node)["hx-$name"]
+Base.setproperty!(x::hx, name::Symbol, v) = attrs(x.node)["hx-$name"] = string(v)
+
+Base.get(x::hx, name, val) = get(attrs(x.node), string(name), string(val))
+Base.get!(x::hx, name, val) = get!(attrs(x.node), string(name), string(val))
+Base.haskey(x::hx, name) = haskey(attrs(x.node), string(name))
+Base.keys(x::hx) = keys(attrs(x.node))
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Cobweb
-using Cobweb: h, hx, Page, Node, attrs, tag, children
+using Cobweb: h, hx, Page, Node, attrs, tag, children, swap
 using Test
 
 n1 = h.div("hi")
@@ -61,6 +61,12 @@ end
     @test nhx.target == "/mytarget"
     @test n.hx.target == "/mytarget"
     @test n.hx.target == attrs(n)["hx-target"]
+
+    @testset "swap" begin
+        @test hx.swap == :swap #swap(:innerHTML) == hx.swap => :innerHTML
+        @test swap() == (:swap => :innerHTML)
+        @test swap(:innerHTML) == (hx.swap => :innerHTML)        
+    end
 
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,11 +63,25 @@ end
     @test n.hx.target == attrs(n)["hx-target"]
 
     @testset "swap" begin
-        @test hx.swap == :swap #swap(:innerHTML) == hx.swap => :innerHTML
-        @test swap() == (:swap => :innerHTML)
-        @test swap(:innerHTML) == (hx.swap => :innerHTML)        
-    end
+        @test hx.swap == :swap
+        @test swap() == (hx.swap => :innerHTML)
+        @test swap(:innerHTML) == (hx.swap => :innerHTML)
+        @test swap.innerHTML == :innerHTML  
+        
+        nhx(:swap, swap.outerHTML)
+        @test n.hx.swap == "outerHTML"
+        nhx.swap = swap.innerHTML
+        @test n.hx.swap == "innerHTML"
+        nhx(:swap => :outerHTML)
+        @test n.hx.swap == "outerHTML"
 
+        nhx("select-oob", "true")
+        @test attrs(n)["hx-select-oob"] == "true"
+
+        nhx.selectoob = "false"
+        @test attrs(n)["hx-select-oob"] == "false"       
+        
+    end
 
 end
 #-----------------------------------------------------------------------------# HTML

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,19 @@ end
     @test o[:] == ["hi"]
     @test collect(o) == ["hi"]
 end
+#-----------------------------------------------------------------------------# HTMX
+@testset "HTMX" begin
+    n = h.div
+    nhx = n.hx
+    nhx.swap = "innerHTML"
+    n.swap = "something else"
+    @test nhx.swap == "innerHTML"
+    @test n.swap == "something else"
+    @test n.hx.swap == "innerHTML"
+    @test n.hx.swap == attrs(n)["hx-swap"]
+    @test n.swap == attrs(n)["swap"]  
+
+end
 #-----------------------------------------------------------------------------# HTML
 @testset "HTML" begin
     @test repr(n1) == "<div>hi</div>"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,6 +82,8 @@ end
         
     end
 
+    #@test string(hx.cdn) == """<script src="https://unpkg.com/htmx.org@1.9.2" integrity="sha384-L6OqL9pRWyyFU3+/bjdSri+iIphTN/bvYyM37tICVyOJkWZLpP2vGn6VUEXgzg6h" crossorigin="anonymous"></script>"""
+
 end
 #-----------------------------------------------------------------------------# HTML
 @testset "HTML" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
 #-----------------------------------------------------------------------------# HTMX
 @testset "HTMX" begin
     n = h.div
-    nhx = n.hx
+    nhx = n.hx    
     nhx.swap = "innerHTML"
     n.swap = "something else"
     @test nhx.swap == "innerHTML"
@@ -57,8 +57,7 @@ end
     
     @test hx.target == :target
 
-    nhx(hx.target, "/mytarget")
-    @test nhx.target == "/mytarget"
+    n = nhx(; hx.target => "/mytarget")
     @test n.hx.target == "/mytarget"
     @test n.hx.target == attrs(n)["hx-target"]
 
@@ -68,18 +67,18 @@ end
         @test swap(:innerHTML) == (hx.swap => :innerHTML)
         @test swap.innerHTML == :innerHTML  
         
-        nhx(:swap, swap.outerHTML)
-        @test n.hx.swap == "outerHTML"
-        nhx.swap = swap.innerHTML
-        @test n.hx.swap == "innerHTML"
-        nhx(:swap => :outerHTML)
-        @test n.hx.swap == "outerHTML"
+        up = nhx(; swap = swap.outerHTML)
+        @test up.hx.swap == "outerHTML"
+        up.hx.swap = swap.innerHTML
+        @test up.hx.swap == "innerHTML"
+        up2 = up.hx(; :swap => :outerHTML)
+        @test up2.hx.swap == "outerHTML"
 
-        nhx("select-oob", "true")
-        @test attrs(n)["hx-select-oob"] == "true"
+        up3 = up2.hx(; Symbol("select-oob") => "true")
+        @test attrs(up3)["hx-select-oob"] == "true"
 
-        nhx.selectoob = "false"
-        @test attrs(n)["hx-select-oob"] == "false"       
+        up3.hx.selectoob = "false"
+        @test attrs(up3)["hx-select-oob"] == "false"       
         
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Cobweb
-using Cobweb: h, Page, Node, attrs, tag, children
+using Cobweb: h, hx, Page, Node, attrs, tag, children
 using Test
 
 n1 = h.div("hi")
@@ -53,7 +53,15 @@ end
     @test n.swap == "something else"
     @test n.hx.swap == "innerHTML"
     @test n.hx.swap == attrs(n)["hx-swap"]
-    @test n.swap == attrs(n)["swap"]  
+    @test n.swap == attrs(n)["swap"] 
+    
+    @test hx.target == :target
+
+    nhx(hx.target, "/mytarget")
+    @test nhx.target == "/mytarget"
+    @test n.hx.target == "/mytarget"
+    @test n.hx.target == attrs(n)["hx-target"]
+
 
 end
 #-----------------------------------------------------------------------------# HTML


### PR DESCRIPTION
The current implementation manages the syntactic sugar that makes HTMX attributes easier to add by the sole usage of `hx` property (added to `Node`).

My aim here was to extend the Cobweb package while keeping the same *look and feel* relative to the development experience.

With the exception of adding the special property to the `Node` (inside `Cobweb.jl` file) value, all the functionality was added to the `htmx.jl` file. 

Also - I added relevant tests and updated the documentation accordingly.

There are cases where the values of the attributes are predefined (e.g., `hx-swap`), and some special syntax can be employed to simplify the workflow even more (see the `swap` work that I started - and also check the tests).

This is for now. I'll consider adding more types in the future - to make sure that illegal states/configuration is unrepresentable.

Regards,